### PR TITLE
Trust llms-unplugged project

### DIFF
--- a/codex/config.toml
+++ b/codex/config.toml
@@ -19,3 +19,5 @@ trust_level = "trusted"
 [projects."/home/ben/projects/slop-university"]
 trust_level = "trusted"
 
+[projects."/home/ben/projects/llms-unplugged"]
+trust_level = "trusted"


### PR DESCRIPTION
## What changed

Adds `/home/ben/projects/llms-unplugged` to the Codex trusted-project profile.

## Why

Allows Codex to run in that local project without a trust prompt.

## Validation

- `git diff --check`
- `codex --profile dotfiles --help`